### PR TITLE
Add snappers to snap a datetoken to a previous or a following day of week

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,19 @@ As you may have noticed, tokens follow a pattern:
   - `/` Snap the date to the start of the snapshot unit.
   - `@` Snap the date to the end of the snapshot unit.
 
-  Snapshot units are the same as arithmetical modifiers, plus `bw`, meaning
-  _business week_. With this, we achieve a simple way to define canonical
-  relative date ranges, such as _Today_ or _Last month_. As an example of
-  the later:
+  Snapshot units are the same as arithmetical modifiers, plus the following
+  ones:
+  - `bw`, business week
+  - `mon`, Monday
+  - `tue`, Tuesday
+  - `wed`, Wednesday
+  - `thu`, Thursday
+  - `fri`, Friday
+  - `sat`, Saturday
+  - `sun`, Sunday
+
+  With this, we achieve a simple way to define canonical relative date ranges,
+  such as _Today_ or _Last month_. As an example of the later:
 
   - String representation: `now-1M/M`, `now-1M@M`
   - Being today _15 Jan 2018_, the result range should be:

--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,20 @@ As you may have noticed, token follow a pattern:
    -  ``/`` Snap the date to the start of the snapshot unit.
    -  ``@`` Snap the date to the end of the snapshot unit.
 
-   Snapshot units are the same as arithmetical modifiers, plus ``bw``,
-   meaning *business week*. With this, we achieve a simple way to define
-   canonical relative date ranges, such as *Today* or *Last month*. As
-   an example of the later:
+  Snapshot units are the same as arithmetical modifiers, plus the following
+  ones:
+
+  - ``bw``, business week
+  - ``mon``, Monday
+  - ``tue``, Tuesday
+  - ``wed``, Wednesday
+  - ``thu``, Thursday
+  - ``fri``, Friday
+  - ``sat``, Saturday
+  - ``sun``, Sunday
+
+  With this, we achieve a simple way to define canonical relative date ranges,
+  such as *Today* or *Last month*. As an example of the later:
 
    -  String representation: ``now-1M/M``, ``now-1M@M``
    -  Being today *15 Jan 2018*, the result range should be: *2018-01-01

--- a/datetoken/ast.py
+++ b/datetoken/ast.py
@@ -100,6 +100,27 @@ class SnapExpression(Expression):
             "bw": lambda dt: (
                 dt - td(days=dt.weekday())
             ).replace(hour=0, minute=0, second=0),
+            "mon": lambda dt: (
+                dt - td(days=dt.weekday())
+            ),
+            "tue": lambda dt: (
+                dt - td(days=((dt.weekday() - 1) % 7))
+            ),
+            "wed": lambda dt: (
+                dt - td(days=((dt.weekday() - 2) % 7))
+            ),
+            "thu": lambda dt: (
+                dt - td(days=((dt.weekday() - 3) % 7))
+            ),
+            "fri": lambda dt: (
+                dt - td(days=((dt.weekday() - 4) % 7))
+            ),
+            "sat": lambda dt: (
+                dt - td(days=((dt.weekday() - 5) % 7))
+            ),
+            "sun": lambda dt: (
+                dt - td(days=((dt.weekday() - 6) % 7))
+            ),
         },
         TokenType.AT: {
             "s": lambda dt: dt.replace(
@@ -121,6 +142,27 @@ class SnapExpression(Expression):
             "bw": lambda dt: (
                 dt - td(days=dt.weekday()) + td(days=4)
             ).replace(hour=23, minute=59, second=59),
+            "mon": lambda dt: (
+                dt + td(days=((0 - dt.weekday()) % 7))
+            ),
+            "tue": lambda dt: (
+                dt + td(days=((1 - dt.weekday()) % 7))
+            ),
+            "wed": lambda dt: (
+                dt + td(days=((2 - dt.weekday()) % 7))
+            ),
+            "thu": lambda dt: (
+                dt + td(days=((3 - dt.weekday()) % 7))
+            ),
+            "fri": lambda dt: (
+                dt + td(days=((4 - dt.weekday()) % 7))
+            ),
+            "sat": lambda dt: (
+                dt + td(days=((5 - dt.weekday()) % 7))
+            ),
+            "sun": lambda dt: (
+                dt + td(days=((6 - dt.weekday()) % 7))
+            ),
         },
     }
 

--- a/datetoken/parser.py
+++ b/datetoken/parser.py
@@ -6,7 +6,8 @@ from .ast import (
 from .token import TokenType
 
 AMOUNT_MODIFIERS = ("s", "m", "h", "d", "w", "M")
-SNAP_MODIFIERS = ("s", "m", "h", "d", "w", "bw", "M")
+SNAP_MODIFIERS = ("s", "m", "h", "d", "w", "bw", "M",
+                  "mon", "tue", "wed", "thu", "fri", "sat", "sun")
 
 
 class Parser(object):

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -21,7 +21,7 @@ class TestLexer(unittest.TestCase):
             self.assertEqual(actual_token.token_literal, exp_token_literal)
 
     def test_next_token(self):
-        token_input = 'now-1h/h@M+2w/bw-3s-49d/m'
+        token_input = 'now-1h/h@M+2w/bw+2d/mon-3s-49d/m'
         # token_input = 'now-1'
         expected = (
             (TokenType.NOW, 'now'),
@@ -37,6 +37,11 @@ class TestLexer(unittest.TestCase):
             (TokenType.MODIFIER, 'w'),
             (TokenType.SLASH, '/'),
             (TokenType.MODIFIER, 'bw'),
+            (TokenType.PLUS, '+'),
+            (TokenType.NUMBER, '2'),
+            (TokenType.MODIFIER, 'd'),
+            (TokenType.SLASH, '/'),
+            (TokenType.MODIFIER, 'mon'),
             (TokenType.MINUS, '-'),
             (TokenType.NUMBER, '3'),
             (TokenType.MODIFIER, 's'),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,18 +23,22 @@ class ParserExpression(unittest.TestCase):
                 self.assertEqual(node.modifier, exp[2])
 
     def test_parse_expression(self):
-        lexer = Lexer("now-1h+w+2M/d-2s@m")
+        lexer = Lexer("now-1h+w+2M/d+2d/thu-2s@m-5w@mon")
         parser = Parser(lexer)
         nodes = parser.parse()
-        self.assertEqual(7, len(nodes))
+        self.assertEqual(11, len(nodes))
         expected = (
             (NowExpression, []),
             (ModifierExpression, 1, "h", "-"),
             (ModifierExpression, 1, "w", "+"),
             (ModifierExpression, 2, "M", "+"),
             (SnapExpression, TokenType.SLASH, "d"),
+            (ModifierExpression, 2, "d", "+"),
+            (SnapExpression, TokenType.SLASH, "thu"),
             (ModifierExpression, 2, "s", "-"),
             (SnapExpression, TokenType.AT, "m"),
+            (ModifierExpression, 5, "w", "-"),
+            (SnapExpression, TokenType.AT, "mon"),
         )
         self.check_expected_nodes(nodes, expected)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -260,6 +260,18 @@ class DateTokenParseToDateTestCase(unittest.TestCase, DatetokenComparatorMixin):
         self.compare_datetime(actual, datetime(2016, 11, 28, 12, 55, 23,
                                                tzinfo=pytz.UTC))
 
+    def test_day_of_week_token_can_be_combined_1(self):
+        payload = 'now@sun/d'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 12, 4, 0, 0, 0,
+                                               tzinfo=pytz.UTC))
+
+    def test_day_of_week_token_can_be_combined_2(self):
+        payload = 'now/sun@d'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 11, 27, 23, 59, 59,
+                                               tzinfo=pytz.UTC))
+
     def test_token_snapped_to_ending_of_month(self):
         payload = 'now@M'
         actual = token_to_date(payload)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,6 +222,44 @@ class DateTokenParseToDateTestCase(unittest.TestCase, DatetokenComparatorMixin):
         self.compare_datetime(actual, datetime(2019, 2, 22, 23, 59, 59,
                                                tzinfo=pytz.UTC))
 
+    def test_token_snapped_to_previous_friday(self):
+        payload = 'now/fri'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 11, 25, 12, 55, 23,
+                                               tzinfo=pytz.UTC))
+
+    def test_token_snapped_to_previous_sunday(self):
+        payload = 'now/sun'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 11, 27, 12, 55, 23,
+                                               tzinfo=pytz.UTC))
+
+    def test_token_snapped_to_prev_monday_yields_today(self):
+        # Today is Monday. Therefore, should snap to today.
+        payload = 'now/mon'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 11, 28, 12, 55, 23,
+                                               tzinfo=pytz.UTC))
+
+    def test_token_snapped_to_following_friday(self):
+        payload = 'now@fri'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 12, 2, 12, 55, 23,
+                                               tzinfo=pytz.UTC))
+
+    def test_token_snapped_to_following_sunday(self):
+        payload = 'now@sun'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 12, 4, 12, 55, 23,
+                                               tzinfo=pytz.UTC))
+
+    def test_token_snapped_to_following_monday(self):
+        # Today is Saturday. Therefore, should snap to today.
+        payload = 'now@mon'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 11, 28, 12, 55, 23,
+                                               tzinfo=pytz.UTC))
+
     def test_token_snapped_to_ending_of_month(self):
         payload = 'now@M'
         actual = token_to_date(payload)


### PR DESCRIPTION
This pull request is a port of sonirico/datetoken.js#3 to the Python version, based in the same principles that rule sonirico/datetoken.js#2. The pull request will add seven new snap expressions to the parser: `mon`, `tue`, `wed`, `thu`, `fri`, `sat` and `sun`.

Each one of these expressions will let a datetoken jump to either the previous (by using the slash) or the following (using the at) day of week matching the day of week given.

So if today is Tuesday, `now@thu` will jump to the following Thursday, which would be equivalent to `now+2d`, for that particular day of the week. And if today is Friday, `now/mon` will jump to the previous Monday, which would be equivalent to `now-4d` for that particular day of the week.