### PR TITLE
Your test suite is failing

### DIFF
--- a/datetoken/lexer.py
+++ b/datetoken/lexer.py
@@ -42,7 +42,7 @@ class Lexer(object):
             tok = Token(TokenType.NOW, 'now')
         elif self.current_char.isdigit():
             return Token(TokenType.NUMBER, self.read_number())
-        elif self.current_char is '':
+        elif self.current_char == '':
             tok = Token(TokenType.END, '')
         elif self.current_char.isalpha():
             return Token(TokenType.MODIFIER, self.read_word())


### PR DESCRIPTION
pyflakes recently added a new kind of lint error that warns against the use of `is` for checking str, bytes and int literals. The rationale behind this new lint warning is described in https://bugs.python.org/issue34850.

> This code "works" on CPython by accident, because of caching on different levels (small integers and strings caches, interned strings, deduplicating constants at compile time). But it shouldn't work on other implementations, and can not work even on early or future CPython versions.

Similar discussions encourage treating is comparations as a bad practice because of the uncertainty it might add during runtime.

Current master branch is green at https://travis-ci.org/sonirico/datetoken/builds/479427724 because the commit was tested days before this feature was merged in the pyflakes source trunk (and therefore in flake8). However, in #1, it fetched a more recent version of flake8 that already includes this lint message, making the same build with older code fail.