### PR TITLE
Import Sequence from collections.abc

### DIFF
--- a/datetoken/exceptions.py
+++ b/datetoken/exceptions.py
@@ -1,4 +1,8 @@
-from collections import Sequence
+try:
+    # Python3.3 and above
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 
 class InvalidTokenException(Exception):


### PR DESCRIPTION
```
datetoken/exceptions.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 will stop working
    from collections import Sequence
```

In Python3.3 the Collections Abstract Base Classes were moved into its own module under `collections`: https://docs.python.org/3.8/library/collections.html

> Deprecated since version 3.3, will be removed in version 3.9: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.8.

The classes itself remain the same, this just changes the import path. This PR changes the current import so that it will try to import from `collections.abc`, which will work on Python3.3 or above, or else fallback into the previous Python2.7 compatible behaviour.