### PR TITLE
Add new year unit Y

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Some common examples of relative tokens:
 | Last business week             | `now-w/bw`     | `now-w@bw`    |
 | This business week             | `now/bw`       | `now@bw`      |
 | Last month                     | `now-1M/M`     | `now-1M@M`    |
+| Last year                      | `now-1Y/Y`     | `now-1Y@Y`    |
 | Next week                      | `now+w/w`      | `now+w@w`     |
 | Custom range                   | `now+w-2d/h`   | `now+2M-10h`  |
 | Last month first business week | `now-M/M+w/bw` | `now-M/+w@bw` |
@@ -66,6 +67,7 @@ As you may have noticed, tokens follow a pattern:
   - `d` days
   - `w` weeks
   - `M` months
+  - `Y` years
 - Optionally, there exist two extra modifiers to snap dates to the start or the
   end of any given snapshot unit. Those are:
   - `/` Snap the date to the start of the snapshot unit.

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ Some common examples of relative tokens:
 -  Last business week: ``now-w/bw``, ``now-w@bw``
 -  This business week: ``now/bw``, ``now@bw``
 -  Last month: ``now-1M/M``, ``now-1M@M``
+-  Last year: ``now-1Y/Y``, ``now-1Y@Y``
 -  Last month first business week: ``now-M/M+w/bw``, ``now-M/M+w@bw``
 
 As you may have noticed, token follow a pattern:
@@ -56,6 +57,7 @@ As you may have noticed, token follow a pattern:
    -  ``d`` days
    -  ``w`` weeks
    -  ``M`` months
+   -  ``Y`` years
 
 -  Optionally, there exist two extra modifiers to snap dates to the
    start or the end of any given snapshot unit. Those are:

--- a/datetoken/ast.py
+++ b/datetoken/ast.py
@@ -54,6 +54,7 @@ class ModifierExpression(Expression):
             "d": lambda dt, amount: dt + td(days=amount),
             "w": lambda dt, amount: dt + td(weeks=amount),
             "M": lambda dt, amount: dt + relativedelta(months=amount),
+            "Y": lambda dt, amount: dt + relativedelta(years=amount),
         },
         TokenType.MINUS: {
             "s": lambda dt, amount: dt - td(seconds=amount),
@@ -62,6 +63,7 @@ class ModifierExpression(Expression):
             "d": lambda dt, amount: dt - td(days=amount),
             "w": lambda dt, amount: dt - td(weeks=amount),
             "M": lambda dt, amount: dt - relativedelta(months=amount),
+            "Y": lambda dt, amount: dt - relativedelta(years=amount),
         },
     }
 
@@ -96,6 +98,9 @@ class SnapExpression(Expression):
             ).replace(hour=0, minute=0, second=0),
             "M": lambda dt: dt.replace(
                 day=1, hour=0, minute=0, second=0
+            ),
+            "Y": lambda dt: dt.replace(
+                month=1, day=1, hour=0, minute=0, second=0
             ),
             "bw": lambda dt: (
                 dt - td(days=dt.weekday())
@@ -139,6 +144,10 @@ class SnapExpression(Expression):
             "M": lambda dt: (
                 dt + relativedelta(months=1, days=-dt.day)
             ).replace(hour=23, minute=59, second=59),
+            "Y": lambda dt: dt.replace(
+                year=dt.year + 1, month=1, day=1,
+                hour=0, minute=0, second=0,
+            ) - relativedelta(seconds=1),
             "bw": lambda dt: (
                 dt - td(days=dt.weekday()) + td(days=4)
             ).replace(hour=23, minute=59, second=59),

--- a/datetoken/parser.py
+++ b/datetoken/parser.py
@@ -5,8 +5,8 @@ from .ast import (
 )
 from .token import TokenType
 
-AMOUNT_MODIFIERS = ("s", "m", "h", "d", "w", "M")
-SNAP_MODIFIERS = ("s", "m", "h", "d", "w", "bw", "M",
+AMOUNT_MODIFIERS = ("s", "m", "h", "d", "w", "M", "Y")
+SNAP_MODIFIERS = ("s", "m", "h", "d", "w", "bw", "M", "Y",
                   "mon", "tue", "wed", "thu", "fri", "sat", "sun")
 
 

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -21,7 +21,7 @@ class TestLexer(unittest.TestCase):
             self.assertEqual(actual_token.token_literal, exp_token_literal)
 
     def test_next_token(self):
-        token_input = 'now-1h/h@M+2w/bw+2d/mon-3s-49d/m'
+        token_input = 'now-1h/h@M+2w/bw+2d/mon-3s-49d/m/tue@Y-wed/Y'
         # token_input = 'now-1'
         expected = (
             (TokenType.NOW, 'now'),
@@ -50,6 +50,14 @@ class TestLexer(unittest.TestCase):
             (TokenType.MODIFIER, 'd'),
             (TokenType.SLASH, '/'),
             (TokenType.MODIFIER, 'm'),
+            (TokenType.SLASH, '/'),
+            (TokenType.MODIFIER, 'tue'),
+            (TokenType.AT, '@'),
+            (TokenType.MODIFIER, 'Y'),
+            (TokenType.MINUS, '-'),
+            (TokenType.MODIFIER, 'wed'),
+            (TokenType.SLASH, '/'),
+            (TokenType.MODIFIER, 'Y'),
             (TokenType.END, ''),
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,6 +68,13 @@ class DateTokenToUTCDateTestCase(unittest.TestCase, DatetokenComparatorMixin):
                                                tzinfo=pytz.UTC))
 
     @freeze_time(datetime(2019, 2, 20, 15, 45, 12))
+    def test_token_snapped_to_beginning_of_year(self):
+        payload = 'now/Y'
+        actual = token_to_utc_date(payload, tz='Europe/Madrid')
+        self.compare_datetime(actual, datetime(2018, 12, 31, 23, 0, 0,
+                                               tzinfo=pytz.UTC))
+
+    @freeze_time(datetime(2019, 2, 20, 15, 45, 12))
     def test_token_snapped_to_beginning_of_business_week(self):
         # TODO: bw is a highly relative concept ;)
         payload = 'now/bw'
@@ -129,6 +136,28 @@ class DateTokenToUTCDateTestCase(unittest.TestCase, DatetokenComparatorMixin):
         self.compare_datetime(actual, datetime(2019, 1, 31, 22, 59, 59,
                                                tzinfo=pytz.UTC))
 
+    def test_token_snapped_to_ending_of_year(self):
+        payload = 'now@Y'
+        actual = token_to_utc_date(payload, tz='Europe/Madrid')
+        self.compare_datetime(actual, datetime(2016, 12, 31, 22, 59, 59,
+                                               tzinfo=pytz.UTC))
+
+    @freeze_time(datetime(2018, 1, 1, 0, 0, 0))
+    def test_token_snapped_to_ending_of_year_edge_case_1(self):
+        # Snap `now` to the beginning of the year
+        payload = 'now@Y'
+        actual = token_to_utc_date(payload, tz='Europe/Madrid')
+        self.compare_datetime(actual, datetime(2018, 12, 31, 22, 59, 59,
+                                               tzinfo=pytz.UTC))
+
+    @freeze_time(datetime(2018, 12, 31, 23, 59, 59))
+    def test_token_snapped_to_ending_of_year_edge_case_2(self):
+        # Snap `now` to the ending of the year
+        payload = 'now@Y'
+        actual = token_to_utc_date(payload, tz='Europe/Madrid')
+        self.compare_datetime(actual, datetime(2019, 12, 31, 22, 59, 59,
+                                               tzinfo=pytz.UTC))
+
     def test_invalid_string_should_raise(self):
         self.assertRaises(InvalidTokenException, token_to_utc_date,
                           'then-1d/d')
@@ -180,6 +209,13 @@ class DateTokenParseToDateTestCase(unittest.TestCase, DatetokenComparatorMixin):
         payload = 'now/M'
         actual = token_to_date(payload)
         self.compare_datetime(actual, datetime(2019, 2, 1, 0, 0, 0,
+                                               tzinfo=pytz.UTC))
+
+    @freeze_time(datetime(2019, 2, 20, 15, 45, 12))
+    def test_token_snapped_to_beginning_of_year(self):
+        payload = 'now/Y'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2019, 1, 1, 0, 0, 0,
                                                tzinfo=pytz.UTC))
 
     @freeze_time(datetime(2019, 2, 20, 15, 45, 12))
@@ -290,6 +326,28 @@ class DateTokenParseToDateTestCase(unittest.TestCase, DatetokenComparatorMixin):
     def test_token_snapped_to_ending_of_month_edge_case_2(self):
         # Snap `now` to the beginning of the month
         payload = 'now@M'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2018, 12, 31, 23, 59, 59,
+                                               tzinfo=pytz.UTC))
+
+    def test_token_snapped_to_ending_of_year(self):
+        payload = 'now@Y'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2016, 12, 31, 23, 59, 59,
+                                               tzinfo=pytz.UTC))
+
+    @freeze_time(datetime(2018, 12, 1, 0, 0, 0))
+    def test_token_snapped_to_ending_of_year_edge_case_1(self):
+        # Snap `now` to the beginning of the year
+        payload = 'now@Y'
+        actual = token_to_date(payload)
+        self.compare_datetime(actual, datetime(2018, 12, 31, 23, 59, 59,
+                                               tzinfo=pytz.UTC))
+
+    @freeze_time(datetime(2018, 12, 31, 23, 59, 59))
+    def test_token_snapped_to_ending_of_year_edge_case_2(self):
+        # Snap `now` to the ending of the year
+        payload = 'now@Y'
         actual = token_to_date(payload)
         self.compare_datetime(actual, datetime(2018, 12, 31, 23, 59, 59,
                                                tzinfo=pytz.UTC))


### PR DESCRIPTION
Not much to say. Works like `M`, but for years. The PR adds new tests (similar to the month ones), and updates the documentation.

---

Aside, individual PRs can be opted-in for Hacktoberfest, rather than having to mark the whole repository with the `hacktoberfest` topic, by assigning a label `hacktoberfest-accepted` to any PR: https://hacktoberfest.digitalocean.com/hacktoberfest-update